### PR TITLE
Adding toggle field value behavior

### DIFF
--- a/switch.php
+++ b/switch.php
@@ -48,5 +48,9 @@ class SwitchField extends CheckboxField {
     }
     return empty($text) ? ' ' : $text;
   }
+  
+  public function result() {
+    return v::accepted(parent::result()) ? 'true' : 'false';
+  }
 
 }


### PR DESCRIPTION
The field is a great replacement for the toggle field which is based on radio field. But the switch field is based on the checkbox field so people who want to replace the toggle field by this have to change not only code but also content for the new values `1` and empty which are used by checkbox field.

This little change brings back the `true` and `false` value so you can easily switch to the switch field if you have used the toggle field before.